### PR TITLE
Remove unneeded Ctrl when switching VTs

### DIFF
--- a/pc-updatemanager
+++ b/pc-updatemanager
@@ -2051,10 +2051,10 @@ shutdown_update() {
   # Determine the tty to display details on
   if [ -e "/dev/ttyv1" ] ; then
     TTY="/dev/ttyv1"
-    FKEY="(Ctrl-Alt-F2 for details)"
+    FKEY="(Alt-F2 for details)"
   elif [ -e "/dev/ttyv2" ] ; then
     TTY="/dev/ttyv2"
-    FKEY="(Ctrl-Alt-F3 for details)"
+    FKEY="(Alt-F3 for details)"
   else
     TTY="/dev/null"
     FKEY=""


### PR DESCRIPTION
We *should* be out of X at this point. Ctrl isn't needed to switch to a different VT when not in X. 
Alt-F2 or Alt-F3 is all that's needed.